### PR TITLE
Make the `Row` TypeScript return type generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ const csv = 'type,part\nunicorn,horn\nrainbow,pink';
 })();
 ```
 */
-declare function neatCsv<Row = neatCsv.Row[]>(
+declare function neatCsv<Row = neatCsv.Row>(
 	data: string | Buffer | ReadableStream,
 	options?: neatCsv.Options
 ): Promise<Row[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,9 +30,9 @@ const csv = 'type,part\nunicorn,horn\nrainbow,pink';
 })();
 ```
 */
-declare function neatCsv(
+declare function neatCsv<Row = neatCsv.Row[]>(
 	data: string | Buffer | ReadableStream,
 	options?: neatCsv.Options
-): Promise<neatCsv.Row[]>;
+): Promise<Row[]>;
 
 export = neatCsv;


### PR DESCRIPTION
When using `mapValues`, you can essentially transform the result of the csv parsing. In order to reflect these changes, one should be able to pass a generic to the neatCsv method that will be used as the resulting data type.