### PR TITLE
Fix TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import {Buffer} from 'node:buffer';
-import {Readable as ReadableStream} from 'node:stream';
+import {ReadableStream} from 'node:stream';
 import {Options} from 'csv-parser';
 
 export type Row = Record<string, string>;


### PR DESCRIPTION
`ReadableStream` is an interface. 
`Readable` is its implementation.

It is more correct to use interface, also it allows to use any stream that implements this interface, ex. any `ReadWrite` stream like `iconv`.
